### PR TITLE
CMS auto build

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "firebase-functions": "^3.1.0",
     "json2csv": "^4.5.2",
     "mailchimp-api-v3": "^1.13.0",
+    "node-fetch": "^2.6.1",
     "node-firestore-import-export": "^0.14.0",
     "nodemailer": "^6.3.1",
     "sib-api-v3-typescript": "^1.2.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.7",
+    "@types/node-fetch": "^2.5.7",
     "firebase-functions-test": "^0.1.6",
     "tslint": "^5.12.0",
     "typescript": "^3.9.7"

--- a/src/CMSRebuild.ts
+++ b/src/CMSRebuild.ts
@@ -1,0 +1,26 @@
+import { functions } from './util';
+import fetch from 'node-fetch';
+
+const CMS_BUILD_WEBHOOK_URL = functions.config().amplify.cms
+
+const callAWSWebhook = async (snap: functions.firestore.QueryDocumentSnapshot, deleted: boolean) => {
+    console.log(`Hackathon ${snap.id} has been ${deleted ? "deleted" : "created"}`)
+    console.log("Triggering a new CMS build..")
+    const res = await fetch(CMS_BUILD_WEBHOOK_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+          },
+        body: JSON.stringify({})
+    })
+    console.log("build webhook called with response:")
+    console.log((await res.text()))
+}
+
+export const CMSRebuildonCreate = functions.firestore.document("Hackathons/{hackathonId}").onCreate(async (snap) => {
+    return callAWSWebhook(snap, false)
+})
+
+export const CMSRebuildonDelete = functions.firestore.document("Hackathons/{hackathonId}").onDelete(async (snap) => {
+    return callAWSWebhook(snap, true)
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 import tagApplicants from "./TagApplicants";
 import setAdmin from "./setAdmin"
 import addToMailingList from "./addToMailingList";
-
+import {CMSRebuildonCreate, CMSRebuildonDelete} from './CMSRebuild';
 /**
  * Export all of our functions so firebase can deploy them
  */
 export {
   setAdmin,
   tagApplicants,
-  addToMailingList
+  addToMailingList,
+  CMSRebuildonCreate,
+  CMSRebuildonDelete
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,6 +850,14 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/node-fetch@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
+  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*", "@types/node@>=8.9.0":
   version "14.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.0.tgz#7d4411bf5157339337d7cff864d9ff45f177b499"
@@ -1527,7 +1535,7 @@ colors@^1.1.2, colors@^1.3.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -2307,6 +2315,15 @@ form-data@^2.5.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:
@@ -3766,6 +3783,11 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-firestore-import-export@^0.14.0:
   version "0.14.1"
@@ -5484,7 +5506,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.2.2:
+typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
## :construction_worker: Changes

This change will trigger CMS builds whenever a hackathon is added or removed from the Hackathons collection in firestore.

It uses a incoming webhook from AWS amplify to trigger the new build. 

## :thought_balloon: Notes

I'm not too worried of causing multiple builds because I think amplify can handle that properly.

## :flashlight: Testing Instructions

If you want to try it out, here are the steps: 
1. go to the nwplus-ubc-dev project on firebase.
2. add or remove a test hackathon from the Hackathons collection. **Please don't remove any of the hackathons with real names, even from the dev database.**
3. Check amplify to see if the build triggered. (optional)
4. After ~10 minutes, check dev.nwplus.io and see if your test hackathon has been added/removed.
